### PR TITLE
feat: HoverCard 组件添加移动端触屏适配

### DIFF
--- a/src/components/ui/hover-card/HoverCard.vue
+++ b/src/components/ui/hover-card/HoverCard.vue
@@ -1,15 +1,31 @@
 <script setup lang="ts">
 import type { HoverCardRootEmits, HoverCardRootProps } from "reka-ui"
-import { HoverCardRoot, useForwardPropsEmits } from "reka-ui"
+import { HoverCardRoot, PopoverRoot, useForwardPropsEmits } from "reka-ui"
+import { useMediaQuery } from "@vueuse/core"
+import { computed, provide } from "vue"
+import { HOVER_CARD_IS_TOUCH_KEY } from "./keys"
 
 const props = defineProps<HoverCardRootProps>()
 const emits = defineEmits<HoverCardRootEmits>()
 
 const forwarded = useForwardPropsEmits(props, emits)
+
+const supportsHover = useMediaQuery("(hover: hover) and (pointer: fine)")
+const isTouch = computed(() => !supportsHover.value)
+
+provide(HOVER_CARD_IS_TOUCH_KEY, isTouch)
 </script>
 
 <template>
+  <PopoverRoot
+    v-if="isTouch"
+    v-slot="slotProps"
+    data-slot="hover-card"
+  >
+    <slot v-bind="slotProps" />
+  </PopoverRoot>
   <HoverCardRoot
+    v-else
     v-slot="slotProps"
     data-slot="hover-card"
     v-bind="forwarded"

--- a/src/components/ui/hover-card/HoverCardContent.vue
+++ b/src/components/ui/hover-card/HoverCardContent.vue
@@ -5,9 +5,13 @@ import { reactiveOmit } from "@vueuse/core"
 import {
   HoverCardContent,
   HoverCardPortal,
+  PopoverContent,
+  PopoverPortal,
   useForwardProps,
 } from "reka-ui"
+import { inject, ref } from "vue"
 import { cn } from "@/lib/utils"
+import { HOVER_CARD_IS_TOUCH_KEY } from "./keys"
 
 defineOptions({
   inheritAttrs: false,
@@ -23,19 +27,27 @@ const props = withDefaults(
 const delegatedProps = reactiveOmit(props, "class")
 
 const forwardedProps = useForwardProps(delegatedProps)
+
+const isTouch = inject(HOVER_CARD_IS_TOUCH_KEY, ref(false))
+
+const contentClasses = 'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 rounded-[10px] border p-4 shadow-md outline-hidden'
 </script>
 
 <template>
-  <HoverCardPortal>
+  <PopoverPortal v-if="isTouch">
+    <PopoverContent
+      data-slot="hover-card-content"
+      v-bind="{ ...$attrs, ...forwardedProps }"
+      :class="cn(contentClasses, props.class)"
+    >
+      <slot />
+    </PopoverContent>
+  </PopoverPortal>
+  <HoverCardPortal v-else>
     <HoverCardContent
       data-slot="hover-card-content"
       v-bind="{ ...$attrs, ...forwardedProps }"
-      :class="
-        cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 rounded-[10px] border p-4 shadow-md outline-hidden',
-          props.class,
-        )
-      "
+      :class="cn(contentClasses, props.class)"
     >
       <slot />
     </HoverCardContent>

--- a/src/components/ui/hover-card/HoverCardTrigger.vue
+++ b/src/components/ui/hover-card/HoverCardTrigger.vue
@@ -1,12 +1,24 @@
 <script setup lang="ts">
 import type { HoverCardTriggerProps } from "reka-ui"
-import { HoverCardTrigger } from "reka-ui"
+import { HoverCardTrigger, PopoverTrigger } from "reka-ui"
+import { inject, ref } from "vue"
+import { HOVER_CARD_IS_TOUCH_KEY } from "./keys"
 
 const props = defineProps<HoverCardTriggerProps>()
+
+const isTouch = inject(HOVER_CARD_IS_TOUCH_KEY, ref(false))
 </script>
 
 <template>
+  <PopoverTrigger
+    v-if="isTouch"
+    data-slot="hover-card-trigger"
+    v-bind="props"
+  >
+    <slot />
+  </PopoverTrigger>
   <HoverCardTrigger
+    v-else
     data-slot="hover-card-trigger"
     v-bind="props"
   >

--- a/src/components/ui/hover-card/keys.ts
+++ b/src/components/ui/hover-card/keys.ts
@@ -1,0 +1,4 @@
+import type { ComputedRef, InjectionKey } from "vue"
+
+export const HOVER_CARD_IS_TOUCH_KEY: InjectionKey<ComputedRef<boolean>> =
+    Symbol("hover-card-is-touch")


### PR DESCRIPTION
## Summary

- HoverCard 组件在触屏设备（手机/平板）上自动退化为 Popover（点击触发弹出卡片）
- 桌面端（有鼠标 hover 能力）保持原有悬浮行为不变
- 通过 useMediaQuery 检测设备能力，使用 provide/inject 在组件树内传递状态
- 所有使用 HoverCard 的页面无需任何修改即可获得移动端适配

## Test plan

- [x] 桌面端浏览器悬浮正常弹出 HoverCard
- [ ] 手机浏览器点击触发弹出 Popover 卡片
- [ ] 点击卡片外区域可关闭弹窗

Made with [Cursor](https://cursor.com)